### PR TITLE
Release v1.2.0

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -1,0 +1,35 @@
+# Credits and Acknowledgments
+
+This project builds upon and incorporates ideas from several excellent Bitcoin network analysis tools:
+
+## Original Script
+- **Samourai Dojo** - The original `ban-knots.sh` script
+  - Repository: https://github.com/Dojo-Open-Source-Project/samourai-dojo
+  - Path: `/docker/my-dojo/bitcoin/ban-knots.sh`
+
+## Enhanced Detection Methods
+
+### Service Flag Detection
+- **gnoban** by caesrcd
+  - Repository: https://github.com/caesrcd/gnoban
+  - Contribution: Service flag 26 (NODE_KNOTS) detection methodology
+  - Enables detection of "hidden" Knots nodes that disguise their user agent
+
+### Historical IP Tracking
+- **Knots-Banlist** by aeonBTC
+  - Repository: https://github.com/aeonBTC/Knots-Banlist
+  - Contribution: Historical database of known Knots node IPs
+  - Provides crowd-sourced IP lists from bitnodes.io snapshots
+
+## Contributors
+- **TMan253** - Umbrel support implementation
+  - Added Docker container execution for Umbrel
+  - Auto-detection of Umbrel environment
+  - Pull Request: #3
+
+## Community
+Thanks to the Bitcoin community for ongoing discussions about network health, transaction relay policies, and node diversity.
+
+---
+
+All code in this repository is released under its original license terms. Please refer to individual source repositories for their specific licensing.

--- a/standalone-ban-knots.sh
+++ b/standalone-ban-knots.sh
@@ -1,8 +1,13 @@
 #!/bin/bash
 
-# Bitcoin Core Knots Node Ban Script
+# Bitcoin Core Knots Node Ban Script v1.2.0
 # This script identifies and bans/disconnects Bitcoin Knots nodes
 # Works with any Bitcoin Core node with RPC enabled
+# 
+# Detection methods:
+# 1. User agent matching (default)
+# 2. Service flag 26 detection (enhanced mode)
+# 3. Historical IP banlist (enhanced mode)
 
 # Default values
 RPC_HOST="127.0.0.1"
@@ -17,6 +22,10 @@ CRON_INTERVAL=10  # minutes
 INSTALL_CRON=false
 UNINSTALL_CRON=false
 COOKIE_PATH=""
+ENHANCED_MODE=true  # Enable service flag detection by default
+USE_EXTERNAL_BANLIST=false  # Don't download external list by default (privacy)
+BANLIST_URL="https://raw.githubusercontent.com/aeonBTC/Knots-Banlist/main/knownknots.txt"
+BANLIST_FILE="$HOME/.bitcoin/knots-banlist.txt"
 DEFAULT_COOKIE_PATHS=(
     "$HOME/.bitcoin/.cookie"
     "$HOME/Library/Application Support/Bitcoin/.cookie"
@@ -63,6 +72,7 @@ Options:
     -d, --duration SECONDS    Ban duration in seconds (default: 5 years)
     -D, --disconnect-only     Only disconnect, don't ban
     -n, --dry-run            Show what would be done without doing it
+    -e, --external-ban-list  Enable external IP banlist download (privacy note: downloads from GitHub)
     -c, --config FILE        Read settings from config file
     --install-cron           Install as cron job (runs every 10 minutes)
     --uninstall-cron         Remove cron job
@@ -198,6 +208,10 @@ while [[ $# -gt 0 ]]; do
             DRY_RUN=true
             shift
             ;;
+        -e|--external-ban-list)
+            USE_EXTERNAL_BANLIST=true
+            shift
+            ;;
         -c|--config)
             read_config "$2"
             CONFIG_FILE="$2"
@@ -293,9 +307,14 @@ if [[ "$INSTALL_CRON" == "true" ]]; then
         CRON_CMD="$SCRIPT_PATH"
     fi
     
-    # Propagate Umbrel mode, if needed
-    if [[ "IS_UMBREL" == "true" ]]; then
+    # Propagate Umbrel mode, if needed - FIX: Add $ to variable
+    if [[ "$IS_UMBREL" == "true" ]]; then
         CRON_CMD="$CRON_CMD --umbrel"
+    fi
+    
+    # Propagate external banlist flag if enabled
+    if [[ "$USE_EXTERNAL_BANLIST" == "true" ]]; then
+        CRON_CMD="$CRON_CMD --external-ban-list"
     fi
     
     # Add logging
@@ -419,7 +438,88 @@ bitcoin_cli() {
     fi
 }
 
-echo "=== Bitcoin Knots Node Ban Script ==="
+# Enhanced detection functions
+# Service flag detection
+has_service_flag() {
+    local services=$1
+    local flag_bit=$2
+    [[ $services == 0x* ]] && services=$((services))
+    (( (services & (1 << flag_bit)) != 0 ))
+}
+
+# Update IP banlist from upstream and merge with local discoveries
+update_banlist() {
+    local need_update=false
+    local temp_file="/tmp/knots-upstream-$$.txt"
+    
+    # Create directory if needed
+    local banlist_dir=$(dirname "$BANLIST_FILE")
+    [[ ! -d "$banlist_dir" ]] && mkdir -p "$banlist_dir"
+    
+    # Only download external list if flag is set
+    if [[ "$USE_EXTERNAL_BANLIST" != true ]]; then
+        # Just create empty file if doesn't exist
+        [[ ! -f "$BANLIST_FILE" ]] && touch "$BANLIST_FILE"
+        return
+    fi
+    
+    # Check if we need to update from upstream
+    if [[ ! -f "$BANLIST_FILE" ]]; then
+        need_update=true
+    else
+        local file_age=$(( $(date +%s) - $(stat -f %m "$BANLIST_FILE" 2>/dev/null || stat -c %Y "$BANLIST_FILE" 2>/dev/null || echo 0) ))
+        if (( file_age > 604800 )); then  # 7 days
+            need_update=true
+        fi
+    fi
+    
+    if [[ "$need_update" == true ]]; then
+        echo "Updating Knots IP banlist from upstream..."
+        if curl -s "$BANLIST_URL" -o "$temp_file" 2>/dev/null || wget -q "$BANLIST_URL" -O "$temp_file" 2>/dev/null; then
+            # Merge upstream with existing local discoveries
+            if [[ -f "$BANLIST_FILE" ]]; then
+                # Extract just IPs from existing file (in case it has timestamps)
+                {
+                    cat "$temp_file"
+                    grep -E "^[0-9a-fA-F:.]+[|$]?" "$BANLIST_FILE" | cut -d'|' -f1
+                } | sort -u > "${BANLIST_FILE}.tmp"
+                mv "${BANLIST_FILE}.tmp" "$BANLIST_FILE"
+                echo "Updated banlist: $(wc -l < "$BANLIST_FILE") total IPs (upstream + local)"
+            else
+                mv "$temp_file" "$BANLIST_FILE"
+                echo "Created banlist: $(wc -l < "$BANLIST_FILE") IPs from upstream"
+            fi
+            rm -f "$temp_file"
+        else
+            echo "Failed to download upstream banlist, using existing"
+        fi
+    fi
+}
+
+# Check if IP is in banlist
+is_banned_ip() {
+    local ip=$1
+    [[ -f "$BANLIST_FILE" ]] && grep -q "^${ip}$" "$BANLIST_FILE"
+}
+
+# Add newly discovered Knots IP to banlist
+add_to_banlist() {
+    local ip=$1
+    local detection_method=$2
+    
+    # Check if IP already in banlist
+    if ! grep -q "^${ip}$" "$BANLIST_FILE"; then
+        echo "$ip" >> "$BANLIST_FILE"
+        echo "  Added new discovery to banlist"
+        
+        # Optional: Keep a log of discoveries with metadata
+        local log_file="${BANLIST_FILE}.log"
+        local timestamp=$(date -u +"%Y-%m-%d %H:%M:%S")
+        echo "${timestamp}|${ip}|${detection_method}" >> "$log_file"
+    fi
+}
+
+echo "=== Bitcoin Knots Node Ban Script v1.2.0 ==="
 if [[ "$IS_START9" == "true" ]]; then
     echo "Platform: Start9 (using podman container)"
 elif [[ "$IS_UMBREL" == "true" ]]; then
@@ -428,6 +528,8 @@ fi
 echo "RPC Host: $RPC_HOST:$RPC_PORT"
 echo "Disconnect Only: $DISCONNECT_ONLY"
 echo "Dry Run: $DRY_RUN"
+echo "Enhanced Detection: $ENHANCED_MODE"
+echo "External Ban List: $USE_EXTERNAL_BANLIST"
 echo ""
 
 # Check if we can connect to the node
@@ -440,6 +542,12 @@ fi
 echo "Successfully connected to Bitcoin node"
 echo ""
 
+# Update banlist if enhanced mode
+if [[ "$ENHANCED_MODE" == true ]]; then
+    update_banlist
+    echo ""
+fi
+
 # Get all peers
 echo "Fetching peer information..."
 PEERS_JSON=$(bitcoin_cli getpeerinfo)
@@ -449,29 +557,132 @@ if [[ -z "$PEERS_JSON" ]]; then
     exit 1
 fi
 
-# Find Knots nodes
-KNOTS_NODES=$(echo "$PEERS_JSON" | jq -r '.[] | select(.subver | contains("Knots")) | {addr: .addr, id: .id, subver: .subver}')
+# Statistics
+TOTAL_PEERS=$(echo "$PEERS_JSON" | jq 'length')
+KNOTS_BY_UA=0
+KNOTS_BY_FLAG=0
+KNOTS_BY_IP=0
+HIDDEN_KNOTS=0
+TOTAL_KNOTS=0
+
+echo "Total peers: $TOTAL_PEERS"
+echo ""
+
+# Detect Knots nodes using all methods
+KNOTS_NODES=""
+
+while IFS= read -r peer; do
+    addr=$(echo "$peer" | jq -r '.addr')
+    id=$(echo "$peer" | jq -r '.id')
+    subver=$(echo "$peer" | jq -r '.subver // ""')
+    services=$(echo "$peer" | jq -r '.services // ""')
+    
+    # Extract IP (handle IPv4, IPv6, and onion addresses)
+    if [[ "$addr" =~ ^\[([^\]]+)\]:[0-9]+$ ]]; then
+        # IPv6 format: [::1]:8333
+        base_addr="${BASH_REMATCH[1]}"
+    elif [[ "$addr" =~ ^([^:]+):[0-9]+$ ]]; then
+        # IPv4 or onion format: 1.2.3.4:8333
+        base_addr="${BASH_REMATCH[1]}"
+    else
+        # No port specified
+        base_addr="$addr"
+    fi
+    
+    is_knots=false
+    detection_methods=""
+    
+    # Method 1: User agent detection
+    if echo "$subver" | grep -qiE "(knots|bitcoinknots)"; then
+        is_knots=true
+        detection_methods="User-Agent"
+        ((KNOTS_BY_UA++))
+    fi
+    
+    # Enhanced detection methods
+    if [[ "$ENHANCED_MODE" == true ]]; then
+        # Method 2: Service flag 26 detection
+        if [[ -n "$services" ]] && has_service_flag "$services" 26; then
+            is_knots=true
+            [[ -n "$detection_methods" ]] && detection_methods="${detection_methods}+ServiceFlag-26" || detection_methods="ServiceFlag-26"
+            ((KNOTS_BY_FLAG++))
+            
+            # Check if it's a hidden node
+            if ! echo "$subver" | grep -qiE "(knots|bitcoinknots)"; then
+                detection_methods="${detection_methods}+HIDDEN"
+                ((HIDDEN_KNOTS++))
+            fi
+        fi
+        
+        # Method 3: IP banlist detection
+        if is_banned_ip "$base_addr"; then
+            is_knots=true
+            [[ -n "$detection_methods" ]] && detection_methods="${detection_methods}+Known-IP" || detection_methods="Known-IP"
+            ((KNOTS_BY_IP++))
+        fi
+    fi
+    
+    # Add to Knots nodes list if detected
+    if [[ "$is_knots" == true ]]; then
+        node_json=$(jq -n --arg addr "$addr" --arg id "$id" --arg subver "$subver" --arg detect "$detection_methods" \
+                   '{addr: $addr, id: $id, subver: $subver, detection: $detect}')
+        if [[ -z "$KNOTS_NODES" ]]; then
+            KNOTS_NODES="$node_json"
+        else
+            KNOTS_NODES="${KNOTS_NODES}\n${node_json}"
+        fi
+        ((TOTAL_KNOTS++))
+    fi
+done < <(echo "$PEERS_JSON" | jq -c '.[]')
 
 if [[ -z "$KNOTS_NODES" ]]; then
     echo "No Knots nodes found among current peers"
+    if [[ "$ENHANCED_MODE" == true ]]; then
+        echo ""
+        echo "Detection summary:"
+        echo "  Checked with user agent: $TOTAL_PEERS peers"
+        echo "  Checked with service flag 26: $TOTAL_PEERS peers"
+        echo "  Checked against IP banlist: $(wc -l < "$BANLIST_FILE" 2>/dev/null || echo 0) IPs"
+    fi
     exit 0
 fi
 
-# Count Knots nodes
-KNOTS_COUNT=$(echo "$KNOTS_NODES" | jq -s 'length')
-echo "Found $KNOTS_COUNT Knots node(s)"
+# Summary
+echo "Found $TOTAL_KNOTS Knots node(s):"
+if [[ "$ENHANCED_MODE" == true ]]; then
+    echo "  By user agent: $KNOTS_BY_UA"
+    echo "  By service flag: $KNOTS_BY_FLAG"
+    echo "  By IP list: $KNOTS_BY_IP"
+    [[ $HIDDEN_KNOTS -gt 0 ]] && echo "  Hidden nodes: $HIDDEN_KNOTS (flag 26 but disguised UA)"
+fi
 echo ""
 
 # Process each Knots node
-echo "$KNOTS_NODES" | jq -c '.' | while read -r node; do
-    addr=$(echo "$node" | jq -r '.addr')
-    id=$(echo "$node" | jq -r '.id')
-    subver=$(echo "$node" | jq -r '.subver')
+echo -e "$KNOTS_NODES" | while IFS= read -r node_json; do
+    [[ -z "$node_json" ]] && continue
+    
+    addr=$(echo "$node_json" | jq -r '.addr')
+    id=$(echo "$node_json" | jq -r '.id')
+    subver=$(echo "$node_json" | jq -r '.subver')
+    detection=$(echo "$node_json" | jq -r '.detection')
     
     # Extract IP address (remove port)
-    base_addr=$(echo "$addr" | sed 's/:.*//' | sed 's/\[//g' | sed 's/\]//g')
+    # Extract IP (handle IPv4, IPv6, and onion addresses)
+    if [[ "$addr" =~ ^\[([^\]]+)\]:[0-9]+$ ]]; then
+        # IPv6 format: [::1]:8333
+        base_addr="${BASH_REMATCH[1]}"
+    elif [[ "$addr" =~ ^([^:]+):[0-9]+$ ]]; then
+        # IPv4 or onion format: 1.2.3.4:8333
+        base_addr="${BASH_REMATCH[1]}"
+    else
+        # No port specified
+        base_addr="$addr"
+    fi
     
     echo "Processing: $addr ($subver)"
+    if [[ "$ENHANCED_MODE" == true ]]; then
+        echo "  Detection: $detection"
+    fi
     
     if [[ "$DISCONNECT_ONLY" == "true" ]]; then
         # Just disconnect
@@ -497,6 +708,8 @@ echo "$KNOTS_NODES" | jq -c '.' | while read -r node; do
             # Then ban
             if bitcoin_cli setban "$base_addr" "add" "$BAN_DURATION" 2>/dev/null; then
                 echo "  Status: Banned successfully"
+                # Add to local discovered list
+                add_to_banlist "$base_addr" "$detection"
             else
                 echo "  Status: Failed to ban (may already be banned)"
             fi
@@ -512,6 +725,18 @@ if [[ "$DISCONNECT_ONLY" == "false" && "$DRY_RUN" == "false" ]]; then
     echo "Current ban list summary:"
     BAN_COUNT=$(bitcoin_cli listbanned | jq 'length')
     echo "Total banned addresses: $BAN_COUNT"
+    
+    # Show banlist info
+    if [[ -f "$BANLIST_FILE" ]]; then
+        BANLIST_COUNT=$(wc -l < "$BANLIST_FILE" | tr -d ' ')
+        echo "Knots IP banlist: $BANLIST_COUNT total IPs"
+        
+        # Show recent discoveries if log exists
+        if [[ -f "${BANLIST_FILE}.log" ]]; then
+            RECENT_DISCOVERIES=$(tail -5 "${BANLIST_FILE}.log" | wc -l | tr -d ' ')
+            echo "Recent discoveries: $RECENT_DISCOVERIES (see ${BANLIST_FILE}.log)"
+        fi
+    fi
 fi
 
 echo "Script completed"


### PR DESCRIPTION
## Overview
This release adds **enhanced detection capabilities** to identify Bitcoin Knots nodes that attempt to hide their identity. The script now uses three detection methods instead of just user agent matching. Additionally, enhanced **Umbrel support** has been integrated for easy deployment on Umbrel nodes.

## New Features

### 1. Service Flag Detection
- Detects nodes advertising service flag 26 (NODE_KNOTS)
- Identifies "hidden" Knots nodes that disguise their user agent but still advertise Knots-specific features
- More reliable than user agent detection alone

### 2. Historical IP Banlist Integration (Optional)
- Downloads known Knots node IPs from [aeonBTC/Knots-Banlist](https://github.com/aeonBTC/Knots-Banlist) when using `--external-ban-list` flag
- Disabled by default for privacy - opt-in with `-e` flag
- Updates weekly from upstream when enabled
- Merges external list with your local discoveries

### 3. Local Discovery Tracking
- Saves discovered Knots IPs to `~/.bitcoin/knots-banlist.txt`
- When `--external-ban-list` is used, merges upstream with local discoveries
- All new discoveries are added to the list
- Optional log file (`knots-banlist.txt.log`) tracks when/how each IP was discovered
- Your personal banlist grows over time

### 4. Enhanced Statistics
- Shows detection breakdown: how many nodes caught by each method
- Highlights "HIDDEN" nodes (those using service flag 26 but disguised user agent)
- Displays count of locally discovered nodes
- Provides summary of all detection methods used

### 5. Umbrel Support
- Auto-detection of Umbrel environment
- Automatic Docker container execution for Umbrel nodes
- `--umbrel` flag for manual override when needed
- Seamless integration with Umbrel's Bitcoin Core setup

## What's Changed
- Service flag detection is **enabled by default** - catches hidden Knots nodes
- **Local discovery tracking always active** - builds your personal Knots IP list at `~/.bitcoin/knots-banlist.txt`
- External IP banlist is **opt-in** with `--external-ban-list` flag (privacy-focused)
  - When enabled: Downloads community list and merges with your local discoveries
  - When disabled: Still saves all discovered IPs locally for future runs
- All existing commands and options work exactly the same
- Output now shows which detection method caught each node
- Added credits to projects that inspired the enhanced detection

## Example Output
```
=== Bitcoin Knots Node Ban Script v1.2.0 ===
Platform: Umbrel (using Docker container)
RPC Host: 127.0.0.1:8332
Enhanced Detection: true
External Ban List: true

Updating Knots IP banlist from upstream...
Updated banlist: 3847 total IPs (upstream + local)

Total peers: 125

Found 15 Knots node(s):
  By user agent: 8
  By service flag: 12
  By IP list: 3
  Hidden nodes: 4 (flag 26 but disguised UA)

Processing: 192.168.1.100:8333 (/Satoshi:28.1.0/)
  Detection: ServiceFlag-26+HIDDEN
  Status: Banned successfully
  Added new discovery to banlist

Current ban list summary:
Total banned addresses: 42
Knots IP banlist: 3862 total IPs
Recent discoveries: 5 (see /home/user/.bitcoin/knots-banlist.txt.log)
```

## Installation

```bash
# Quick install with auto-detection
wget https://github.com/noosphere888/Ban-Knots/releases/download/v1.2.0/standalone-ban-knots.sh && \
chmod +x standalone-ban-knots.sh && \
./standalone-ban-knots.sh --install-cron
```

## Credits
- Service flag detection inspired by [caesrcd/gnoban](https://github.com/caesrcd/gnoban)
- IP banlist from [aeonBTC/Knots-Banlist](https://github.com/aeonBTC/Knots-Banlist)
- Umbrel support contributed by [TMan253](https://github.com/TMan253)

## Compatibility
- Fully backward compatible with v1.1.0
- No breaking changes
- All existing cron jobs continue to work
- Works seamlessly on Umbrel, Start9, and standard Bitcoin Core installations